### PR TITLE
Add option to return single/multiple studios

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -50,4 +50,7 @@ msgstr ""
 
 msgctxt "#30008"
 msgid "Certification Prefix"
+
+msgctxt "#30009"
+msgid "Add multiple studios"
 msgstr ""

--- a/resources/language/resource.language.en_nz/strings.po
+++ b/resources/language/resource.language.en_nz/strings.po
@@ -50,4 +50,7 @@ msgstr ""
 
 msgctxt "#30008"
 msgid "Certification Prefix"
+
+msgctxt "#30009"
+msgid "Add multiple studios"
 msgstr ""

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -50,4 +50,7 @@ msgstr ""
 
 msgctxt "#30008"
 msgid "Certification Prefix"
+msgctxt "#30009"
+
+msgid "Add multiple studios"
 msgstr ""

--- a/resources/lib/main.py
+++ b/resources/lib/main.py
@@ -175,6 +175,10 @@ def get_details(mid):
 
         imdb_info = get_imdb_ratinginfo(movie.imdb_id)
 
+        studios = get_names(movie.production_companies)
+        if not ADDON.getSettingBool('multiple_studios'):
+            studios = studios[:1]
+
         liz.setInfo('video',
             {'title': title,
                 'originaltitle': movie.original_title,
@@ -191,7 +195,7 @@ def get_details(mid):
                 'director': get_cast_members(movie.casts, 'crew', 'Directing', ['Director']),
                 'set': get_set(movie.belongs_to_collection) if \
                     movie.belongs_to_collection else get_set(movie_en.belongs_to_collection),
-                'studio': get_names(movie.production_companies),
+                'studio': studios,
                 'premiered': movie.release_date
         })
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,4 +7,5 @@
     <setting label="30006" type="select" values="au|bg|br|ca|cz|ge|de|dk|ee|es|fi|fr|gb|gr|hr|hu|id|il|in|it|ir|jp|kr|lt|lv|mx|nl|no|pl|pt|ru|si|sv|th|tr|ua|us|vn|zh" id="tmdbcertcountry" default="us"/>
     <setting label="30008" type="text" id="certprefix" default="Rated " />
     <setting label="30003" type="labelenum" values="TMDb|IMDb" id="RatingS" default="TMDb"/>
+    <setting label="30009" type="bool" id="multiple_studios" default="false" />
 </settings>


### PR DESCRIPTION
A single studio must be used to match studio image files, but multiple studios are often involved. The XML scraper only adds the first studio, this Python scraper started with all studios, this PR splits the difference and adds an option to swap. Defaults to single studio.