### PR TITLE
Search improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 This is early work on a Python movie scraper for Kodi.
 
+### Manual search by IMDB / TMDB ID
+When manually searching you can enter an IMDB or TMDB ID to pull up an exact movie result.
+To search by TMDB enter "tmdb/" then the ID, like "tmdb/11". To search by IMDB ID enter it directly.
+
 ## Development info
 
 ### How to run unit tests
 
-`python -m unittest discover -v` from the main __metadata.themoviedb.org.python__ directory.
+`python -m unittest discover -v` from the main **metadata.themoviedb.org.python** directory.
 Python 3 only.

--- a/python/scraper.py
+++ b/python/scraper.py
@@ -34,8 +34,9 @@ def search_for_movie(title, year, handle):
 
     for movie in search_results:
         listitem = xbmcgui.ListItem(movie['title'], offscreen=True)
-        if year:
-            listitem.setInfo('video', {'year': year})
+        movie_year = movie.get('release_date', '')[0]
+        if movie_year:
+            listitem.setInfo('video', {'year': movie_year})
         if movie['poster_path']:
             listitem.setArt({'thumb': movie['poster_path']})
         uniqueids = {'tmdb': str(movie['id'])}

--- a/python/scraper.py
+++ b/python/scraper.py
@@ -21,7 +21,8 @@ def log(msg, level=xbmc.LOGDEBUG):
     xbmc.log(msg='{addon}: {msg}'.format(addon=ID, msg=msg), level=level)
 
 def search_for_movie(title, year, handle):
-    log('Find movie with title {title} from year {year}'.format(title=title, year=year), xbmc.LOGINFO)
+    log("Find movie with title '{title}' from year '{year}'".format(title=title, year=year), xbmc.LOGINFO)
+    title = _strip_trailing_article(title)
     search_results = scraper.search(title, year)
     if not search_results:
         return
@@ -40,6 +41,14 @@ def search_for_movie(title, year, handle):
         uniqueids = {'tmdb': str(movie['id'])}
         xbmcplugin.addDirectoryItem(handle=handle, url=json.dumps(uniqueids),
             listitem=listitem, isFolder=True)
+
+_articles = [prefix + article for prefix in (', ', ' ') for article in ("the", "a", "an")]
+def _strip_trailing_article(title):
+    title = title.lower()
+    for article in _articles:
+        if title.endswith(article):
+            return title[:-len(article)]
+    return title
 
 # Low limit because a big list of artwork can cause trouble in some cases
 # (a column can be too large for the MySQL integration),


### PR DESCRIPTION
Cut off trailing article for search to work with recent changes to TMDB. Just "The", "An", and "A".

And supports manual search by IMDB or TMDB ID rather than movie title. To search by IMDB ID enter it directly, and by TMDB ID enter "tmdb/" then the ID, like "tmdb/11".

Closes #10 and #11 .