### PR TITLE
add options to disable ratings from IMDB/Trakt

### DIFF
--- a/python/scraper.py
+++ b/python/scraper.py
@@ -83,15 +83,17 @@ def get_details(input_uniqueids, handle, settings):
         log(header + ': ' + details['error'], xbmc.LOGWARNING)
         return False
 
-    imdbinfo = get_imdb_details(details['uniqueids'])
-    if 'error' in imdbinfo:
-        header = "The Movie Database Python error with website IMDB"
-        log(header + ': ' + imdbinfo['error'], xbmc.LOGWARNING)
-    else:
-        details = combine_scraped_details_info_and_ratings(details, imdbinfo)
+    if settings.getSettingString('RatingS') == 'IMDb' or settings.getSettingBool('imdbanyway'):
+        imdbinfo = get_imdb_details(details['uniqueids'])
+        if 'error' in imdbinfo:
+            header = "The Movie Database Python error with website IMDB"
+            log(header + ': ' + imdbinfo['error'], xbmc.LOGWARNING)
+        else:
+            details = combine_scraped_details_info_and_ratings(details, imdbinfo)
 
-    traktinfo = get_trakt_ratinginfo(details['uniqueids'])
-    details = combine_scraped_details_info_and_ratings(details, traktinfo)
+    if settings.getSettingString('RatingS') == 'Trakt' or settings.getSettingBool('traktanyway'):
+        traktinfo = get_trakt_ratinginfo(details['uniqueids'])
+        details = combine_scraped_details_info_and_ratings(details, traktinfo)
 
     details = configure_scraped_details(details, settings)
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -55,3 +55,7 @@ msgstr ""
 msgctxt "#30009"
 msgid "Add multiple studios"
 msgstr ""
+
+msgctxt "#30010"
+msgid "Add also Trakt.tv ratings"
+msgstr ""

--- a/resources/language/resource.language.en_nz/strings.po
+++ b/resources/language/resource.language.en_nz/strings.po
@@ -55,3 +55,7 @@ msgstr ""
 msgctxt "#30009"
 msgid "Add multiple studios"
 msgstr ""
+
+msgctxt "#30010"
+msgid "Add also Trakt.tv ratings"
+msgstr ""

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -55,3 +55,7 @@ msgstr ""
 msgctxt "#30009"
 msgid "Add multiple studios"
 msgstr ""
+
+msgctxt "#30010"
+msgid "Add also Trakt.tv ratings"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,6 +7,8 @@
     <setting label="30006" type="select" values="au|bg|br|ca|cz|ge|de|dk|ee|es|fi|fr|gb|gr|hr|hu|id|il|in|it|ir|jp|kr|lt|lv|mx|nl|no|pl|pt|ru|si|sv|th|tr|ua|us|vn|zh" id="tmdbcertcountry" default="us"/>
     <setting label="30008" type="text" id="certprefix" default="Rated " />
     <setting label="30003" type="labelenum" values="TMDb|IMDb|Trakt" id="RatingS" default="TMDb"/>
+    <setting label="30007" type="bool" id="imdbanyway" visible="!eq(-1,1)" default="false"/>
+    <setting label="30010" type="bool" id="traktanyway" visible="!eq(-2,2)" default="false"/>
     <setting label="30009" type="bool" id="multiple_studios" default="false" />
     <!-- For add-on inner workings -->
     <setting id="lastUpdated" type="text" default="0" visible="false" />


### PR DESCRIPTION
Disabling IMDB ratings greatly improves scraping speed - with IMDB disabled the scraper takes 0.59x the time it takes with IMDB enabled.

This switch behaves the same as it does for the XML scraper - no request will be made to IMDB, so top250 will also be excluded. Disabled by default like the XML scraper.

Disabling Trakt.tv doesn't have near the effect on speed, but the switch is still handy.