### PR TITLE
fix: don't double-decode parameter values

### DIFF
--- a/python/scraper_datahelper.py
+++ b/python/scraper_datahelper.py
@@ -1,10 +1,8 @@
 import re
 try:
-    import urlparse
-    from urllib import unquote_plus
+    from urlparse import parse_qsl
 except ImportError: # py2 / py3
-    from urllib import parse as urlparse
-    from urllib.parse import unquote_plus
+    from urllib.parse import parse_qsl
 
 # get addon params from the plugin path querystring
 def get_params(argv):
@@ -12,8 +10,7 @@ def get_params(argv):
     if len(argv) < 2 or not argv[1]:
         return result
 
-    result_list = [(key, unquote_plus(value)) for key, value in urlparse.parse_qsl(argv[1].lstrip('?'))]
-    result.update(result_list)
+    result.update(parse_qsl(argv[1].lstrip('?')))
     return result
 
 def combine_scraped_details_info_and_ratings(original_details, additional_details):

--- a/test/unittests/test_scraper_datahelper.py
+++ b/test/unittests/test_scraper_datahelper.py
@@ -45,6 +45,14 @@ class TestScraperDatahelper(unittest.TestCase):
 
         self.assertDictEqual(expected_output, actual_output)
 
+    def test_get_params__some_random_querystring_with_percent(self):
+        input_model = ('1', "?acorns=%25100%20nested")
+        expected_output = {'handle': 1, 'acorns': '%100 nested'}
+
+        actual_output = scraper_datahelper.get_params(input_model)
+
+        self.assertDictEqual(expected_output, actual_output)
+
 
     def test_combine_scraped_details_info_and_ratings(self):
         input_model1 = {'info': {'bit': 1}, 'ratings': {'w1': {'rating': 1, 'votes': 2}}}


### PR DESCRIPTION
`parse_qsl` already percent-decodes values, no need to decode again with `unquote_plus`.