### PR TITLE
fix: wrap settings in a category

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <settings>
-    <setting label="30005" type="bool" id="keeporiginaltitle" default="false"/>
-    <setting label="30000" type="bool" id="fanart" default="true"/>
-    <setting label="30004" type="bool" id="trailer" default="true"/>
-	<setting label="30002" type="select" values="ar-AE|ar-SA|bg|bn-BD|ca-ES|ch-GU|cs|da|de|el|en|eo-EO|es|es-MX|eu-ES|fa|fa-ir|fi|fr|fr-CA|gl|he|hi-IN|hr|hu|id-ID|it|ja|ka-GE|ko|lt-LT|lv-LV|ml-IN|nb|nl|no|pl|pt|pt-br|ro|ru|sk|sl|sr|sv|ta-IN|th|tr|uk|vi-VN|zh|zh-tw|zh-hk" id="language" default="en"/>
-    <setting label="30006" type="select" values="au|bg|br|ca|cz|ge|de|dk|ee|es|fi|fr|gb|gr|hr|hu|id|il|in|it|ir|jp|kr|lt|lv|mx|nl|no|pl|pt|ru|si|sv|th|tr|ua|us|vn|zh" id="tmdbcertcountry" default="us"/>
-    <setting label="30008" type="text" id="certprefix" default="Rated " />
-    <setting label="30003" type="labelenum" values="TMDb|IMDb|Trakt" id="RatingS" default="TMDb"/>
-    <setting label="30007" type="bool" id="imdbanyway" visible="!eq(-1,1)" default="false"/>
-    <setting label="30010" type="bool" id="traktanyway" visible="!eq(-2,2)" default="false"/>
-    <setting label="30009" type="bool" id="multiple_studios" default="false" />
-    <setting label="30011" type="bool" id="add_tags" default="true" />
-    <!-- For add-on inner workings -->
-    <setting id="lastUpdated" type="text" default="0" visible="false" />
-    <setting id="originalUrl" type="text" default="" visible="false" />
-    <setting id="previewUrl" type="text" default="" visible="false" />
+	<category label="$LOCALIZE[128]">
+		<setting label="30005" type="bool" id="keeporiginaltitle" default="false"/>
+		<setting label="30000" type="bool" id="fanart" default="true"/>
+		<setting label="30004" type="bool" id="trailer" default="true"/>
+		<setting label="30002" type="select" values="ar-AE|ar-SA|bg|bn-BD|ca-ES|ch-GU|cs|da|de|el|en|eo-EO|es|es-MX|eu-ES|fa|fa-ir|fi|fr|fr-CA|gl|he|hi-IN|hr|hu|id-ID|it|ja|ka-GE|ko|lt-LT|lv-LV|ml-IN|nb|nl|no|pl|pt|pt-br|ro|ru|sk|sl|sr|sv|ta-IN|th|tr|uk|vi-VN|zh|zh-tw|zh-hk" id="language" default="en"/>
+		<setting label="30006" type="select" values="au|bg|br|ca|cz|ge|de|dk|ee|es|fi|fr|gb|gr|hr|hu|id|il|in|it|ir|jp|kr|lt|lv|mx|nl|no|pl|pt|ru|si|sv|th|tr|ua|us|vn|zh" id="tmdbcertcountry" default="us"/>
+		<setting label="30008" type="text" id="certprefix" default="Rated " />
+		<setting label="30003" type="labelenum" values="TMDb|IMDb|Trakt" id="RatingS" default="TMDb"/>
+		<setting label="30007" type="bool" id="imdbanyway" visible="!eq(-1,1)" default="false"/>
+		<setting label="30010" type="bool" id="traktanyway" visible="!eq(-2,2)" default="false"/>
+		<setting label="30009" type="bool" id="multiple_studios" default="false" />
+		<setting label="30011" type="bool" id="add_tags" default="true" />
+		<!-- For add-on inner workings -->
+		<setting id="lastUpdated" type="text" default="0" visible="false" />
+		<setting id="originalUrl" type="text" default="" visible="false" />
+		<setting id="previewUrl" type="text" default="" visible="false" />
+	</category>
 </settings>


### PR DESCRIPTION
So the add-on configuration page doesn't show just a blank box for the "tab" selection. The string is "General".