### PR TITLE
Change 'landscape from TMDb' option disabled behavior to keep titled fanart

### DIFF
--- a/python/scraper_config.py
+++ b/python/scraper_config.py
@@ -12,15 +12,20 @@ def configure_tmdb_artwork(details, settings):
         return details
 
     art = details['available_art']
-    if not settings.getSettingBool('fanart'):
+    fanart_enabled = settings.getSettingBool('fanart')
+    if not fanart_enabled:
         if 'fanart' in art:
             del art['fanart']
         if 'set.fanart' in art:
             del art['set.fanart']
     if not settings.getSettingBool('landscape'):
         if 'landscape' in art:
+            if fanart_enabled:
+                art['fanart'] = art.get('fanart', []) + art['landscape']
             del art['landscape']
         if 'set.landscape' in art:
+            if fanart_enabled:
+                art['set.fanart'] = art.get('set.fanart', []) + art['set.landscape']
             del art['set.landscape']
 
     return details

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -65,7 +65,7 @@ msgid "Add keywords as tags"
 msgstr ""
 
 msgctxt "#30012"
-msgid "Enable landscape from TMDb"
+msgid "Separate TMDb fanart with title to landscape"
 msgstr ""
 
 msgctxt "#30100"

--- a/resources/language/resource.language.en_nz/strings.po
+++ b/resources/language/resource.language.en_nz/strings.po
@@ -65,7 +65,7 @@ msgid "Add keywords as tags"
 msgstr ""
 
 msgctxt "#30012"
-msgid "Enable landscape from TMDb"
+msgid "Separate TMDb fanart with title to landscape"
 msgstr ""
 
 msgctxt "#30100"

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -65,7 +65,7 @@ msgid "Add keywords as tags"
 msgstr ""
 
 msgctxt "#30012"
-msgid "Enable landscape from TMDb"
+msgid "Separate TMDb fanart with title to landscape"
 msgstr ""
 
 msgctxt "#30100"


### PR DESCRIPTION
When the "landscape from TMDb" option is disabled, add titled fanart (fanart with language) back to the fanart list.