### PR TITLE
remove external module dependencies

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org.python"
        name="The Movie Database Python"
-       version="1.2.2"
+       version="1.3.0"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
@@ -11,13 +11,15 @@
              library="python/scraper.py"/>
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
-    <news>v1.2.1 (2020-08-08)
+    <news>v1.3.0 (2020-10-04)
+- Change: removed dependencies on requests, tmdbsimple, and trakt modules
+- Change: images now returned with initial API call instead of during fallback
+- Change: settings language for TMDb now use culture name (i.e. en-US) - required for direct API call
+
+v1.2.1 (2020-08-08)
 - Fix: Prefer movies that exactly match search title and year
 - Fix: Change 'landscape from TMDb' option disabled behavior to keep titled fanart
-
-v1.2.0 (2020-05-25)
-- Feature: add extended artwork from Fanart.tv
-- Feature: separate 'fanart' images with language to 'landscape' art type</news>
+</news>
     <summary lang="af_ZA">TMDB Fliek Skraper</summary>
     <summary lang="be_BY">TMDB Movie Scraper</summary>
     <summary lang="bg_BG">Сваля инф. за филми от TMDB</summary>

--- a/addon.xml
+++ b/addon.xml
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org.python"
        name="The Movie Database Python"
-       version="1.2.1"
+       version="1.2.2"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
     <import addon="xbmc.python" version="2.26.0"/>
-    <import addon="script.module.requests" version="2.9.1"/>
-    <import addon="script.module.trakt" version="3.1.0"/>
-    <import addon="script.module.tmdbsimple" version="2.2.0"/>
-    <import addon="plugin.video.youtube" version="4.4.10" optional="true"/>
   </requires>
   <extension point="xbmc.metadata.scraper.movies"
              library="python/scraper.py"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+v1.2.2 (2020-10-04)
+- Fix: removed dependencies on requests, tmdbsimple, and trakt modules
+- Fix: images now returned with initial API call instead of during fallback
+- Fix: settings language for TMDb now use culture name (i.e. en-US) - required for direct API call
+
 v1.2.1 (2020-08-08)
 - Fix: Prefer movies that exactly match search title and year
 - Fix: Change 'landscape from TMDb' option disabled behavior to keep titled fanart

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
-v1.2.2 (2020-10-04)
-- Fix: removed dependencies on requests, tmdbsimple, and trakt modules
-- Fix: images now returned with initial API call instead of during fallback
-- Fix: settings language for TMDb now use culture name (i.e. en-US) - required for direct API call
+v1.3.0 (2020-10-04)
+- Change: removed dependencies on requests, tmdbsimple, and trakt modules
+- Change: images now returned with initial API call instead of during fallback
+- Change: settings language for TMDb now use culture name (i.e. en-US) - required for direct API call
 
 v1.2.1 (2020-08-08)
 - Fix: Prefer movies that exactly match search title and year

--- a/python/lib/tmdbscraper/api_utils.py
+++ b/python/lib/tmdbscraper/api_utils.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+#
+# Copyright (C) 2020, Team Kodi
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Functions to interact with various web site APIs."""
+
+from __future__ import absolute_import, unicode_literals
+
+import json, xbmc
+# from pprint import pformat
+try: #PY2 / PY3
+    from urllib2 import Request, urlopen
+    from urllib2 import URLError
+    from urllib import urlencode
+except ImportError:
+    from urllib.request import Request, urlopen
+    from urllib.error import URLError
+    from urllib.parse import urlencode
+try:
+    from typing import Text, Optional, Union, List, Dict, Any  # pylint: disable=unused-import
+    InfoType = Dict[Text, Any]  # pylint: disable=invalid-name
+except ImportError:
+    pass
+
+HEADERS = {}
+
+
+def set_headers(headers):
+    HEADERS.update(headers)
+
+
+def load_info(url, params=None, default=None, resp_type = 'json'):
+    # type: (Text, Optional[Dict[Text, Union[Text, List[Text]]]]) -> Union[dict, list]
+    """
+    Load info from external api
+
+    :param url: API endpoint URL
+    :param params: URL query params
+    :default: object to return if there is an error
+    :resp_type: what to return to the calling function
+    :return: API response or default on error
+    """
+    theerror = ''
+    if params:
+        url = url + '?' + urlencode(params)
+    xbmc.log('Calling URL "{}"'.format(url), xbmc.LOGDEBUG)
+    req = Request(url, headers=HEADERS)
+    try:
+        response = urlopen(req)
+    except URLError as e:
+        if hasattr(e, 'reason'):
+            theerror = {'error': 'failed to reach the remote site\nReason: {}'.format(e.reason)}
+        elif hasattr(e, 'code'):
+            theerror = {'error': 'remote site unable to fulfill the request\nError code: {}'.format(e.code)}
+        if default is not None:
+            return default
+        else:
+            return theerror
+    if resp_type.lower() == 'json':
+        resp = json.loads(response.read().decode('utf-8'))
+    else:
+        resp = response.read().decode('utf-8')
+    # xbmc.log('the api response:\n{}'.format(pformat(resp)), xbmc.LOGDEBUG)
+    return resp

--- a/python/lib/tmdbscraper/fanarttv.py
+++ b/python/lib/tmdbscraper/fanarttv.py
@@ -1,5 +1,4 @@
-import requests
-from requests.exceptions import ConnectionError as RequestsConnectionError, Timeout, RequestException
+from . import api_utils
 try:
     from urllib import quote
 except ImportError: # py2 / py3
@@ -52,22 +51,9 @@ def _get_data(media_id, clientkey):
     headers = {'api-key': API_KEY}
     if clientkey:
         headers['client-key'] = clientkey
-
-    try:
-        response = requests.get(API_URL.format(media_id), headers=headers)
-    except (Timeout, RequestsConnectionError, RequestException) as ex:
-        return _format_error_message(ex)
-
-    if not response or not response.status_code == 200:
-        return None
-
-    return response.json()
-
-def _format_error_message(ex):
-    message = type(ex).__name__
-    if hasattr(ex, 'message'):
-        message += ": {0}".format(ex.message)
-    return {'error': message}
+    api_utils.set_headers(headers)
+    fanarttv_url = API_URL.format(media_id)
+    return api_utils.load_info(fanarttv_url, default={})
 
 def _parse_data(data, language):
     result = {}

--- a/python/lib/tmdbscraper/tmdbapi.py
+++ b/python/lib/tmdbscraper/tmdbapi.py
@@ -1,0 +1,132 @@
+# -*- coding: UTF-8 -*-
+#
+# Copyright (C) 2020, Team Kodi
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# pylint: disable=missing-docstring
+
+"""Functions to interact with TMDb API."""
+
+from . import api_utils
+import xbmc
+try:
+    from typing import Optional, Text, Dict, List, Any  # pylint: disable=unused-import
+    InfoType = Dict[Text, Any]  # pylint: disable=invalid-name
+except ImportError:
+    pass
+
+
+HEADERS = (
+    ('User-Agent', 'Kodi Movie scraper by Team Kodi'),
+    ('Accept', 'application/json'),
+)
+api_utils.set_headers(dict(HEADERS))
+
+TMDB_PARAMS = {'api_key': 'f090bb54758cabf231fb605d3e3e0468'}
+BASE_URL = 'https://api.themoviedb.org/3/{}'
+SEARCH_URL = BASE_URL.format('search/movie')
+FIND_URL = BASE_URL.format('find/{}')
+MOVIE_URL = BASE_URL.format('movie/{}')
+COLLECTION_URL = BASE_URL.format('collection/{}')
+CONFIG_URL = BASE_URL.format('configuration')
+
+
+def search_movie(query, year=None, language=None):
+    # type: (Text) -> List[InfoType]
+    """
+    Search for a movie
+
+    :param title: movie title to search
+    :param year: the year to search (optional)
+    :param language: the language filter for TMDb (optional)
+    :return: a list with found movies
+    """
+    xbmc.log('using title of %s to find movie' % query, xbmc.LOGDEBUG)
+    theurl = SEARCH_URL
+    params = _set_params(None, language)
+    params['query'] = query
+    if year is not None:
+        params['year'] = str(year)
+    return api_utils.load_info(theurl, params=params)
+
+
+def find_movie_by_external_id(external_id, language=None):
+    # type: (Text) -> List[InfoType]
+    """
+    Find movie based on external ID
+
+    :param mid: external ID
+    :param language: the language filter for TMDb (optional)
+    :return: the movie or error
+    """
+    xbmc.log('using external id of %s to find movie' % external_id, xbmc.LOGDEBUG)
+    theurl = FIND_URL.format(external_id)
+    params = _set_params(None, language)
+    params['external_source'] = 'imdb_id'
+    return api_utils.load_info(theurl, params=params)
+
+
+
+def get_movie(mid, language=None, append_to_response=None):
+    # type: (Text) -> List[InfoType]
+    """
+    Get movie details
+
+    :param mid: TMDb movie ID
+    :param language: the language filter for TMDb (optional)
+    :append_to_response: the additional data to get from TMDb (optional)
+    :return: the movie or error
+    """
+    xbmc.log('using movie id of %s to get movie details' % mid, xbmc.LOGDEBUG)
+    theurl = MOVIE_URL.format(mid)
+    return api_utils.load_info(theurl, params=_set_params(append_to_response, language))
+
+
+def get_collection(collection_id, language=None, append_to_response=None):
+    # type: (Text) -> List[InfoType]
+    """
+    Get movie collection information
+
+    :param collection_id: TMDb collection ID
+    :param language: the language filter for TMDb (optional)
+    :append_to_response: the additional data to get from TMDb (optional)
+    :return: the movie or error
+    """
+    xbmc.log('using collection id of %s to get collection details' % collection_id, xbmc.LOGDEBUG)
+    theurl = COLLECTION_URL.format(collection_id)
+    return api_utils.load_info(theurl, params=_set_params(append_to_response, language))
+
+
+def get_configuration():
+    # type: (Text) -> List[InfoType]
+    """
+    Get configuration information
+
+    :return: configuration details or error
+    """
+    xbmc.log('getting configuration details', xbmc.LOGDEBUG)
+    return api_utils.load_info(CONFIG_URL, params=TMDB_PARAMS.copy())
+
+
+def _set_params(append_to_response, language):
+    params = TMDB_PARAMS.copy()
+    img_lang = 'en,null'
+    if language is not None:
+        params['language'] = language
+        img_lang = '%s,en,null' % language[0:2]
+    if append_to_response is not None:
+        params['append_to_response'] = append_to_response
+        if 'images' in append_to_response:
+            params['include_image_language'] = img_lang
+    return params

--- a/python/lib/tmdbscraper/traktratings.py
+++ b/python/lib/tmdbscraper/traktratings.py
@@ -1,26 +1,55 @@
-from trakt import Trakt
-from trakt.objects import Movie
+# -*- coding: UTF-8 -*-
+#
+# Copyright (C) 2020, Team Kodi
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# pylint: disable=missing-docstring
 
+"""Functions to interact with Trakt API."""
+
+from __future__ import absolute_import, unicode_literals
+
+from . import api_utils
 from . import get_imdb_id
+try:
+    from typing import Optional, Text, Dict, List, Any  # pylint: disable=unused-import
+    InfoType = Dict[Text, Any]  # pylint: disable=invalid-name
+except ImportError:
+    pass
 
-# get the movie info via imdb
+
+HEADERS = (
+    ('User-Agent', 'Kodi Movie scraper by Team Kodi'),
+    ('Accept', 'application/json'),
+    ('trakt-api-key', '5f2dc73b6b11c2ac212f5d8b4ec8f3dc4b727bb3f026cd254d89eda997fe64ae'),
+    ('trakt-api-version', '2'),
+    ('Content-Type', 'application/json'),
+)
+api_utils.set_headers(dict(HEADERS))
+
+MOVIE_URL = 'https://api.trakt.tv/movies/{}'
+
+
 def get_trakt_ratinginfo(uniqueids):
-    __client_id = "5f2dc73b6b11c2ac212f5d8b4ec8f3dc4b727bb3f026cd254d89eda997fe64ae"
-    __client_secret = "7b9ce1836d6f5c60fc78809d5455afaeb33236d86545ec860e814d3d4aae7b5c"
-    # Configure
-    Trakt.configuration.defaults.client(
-        id=__client_id,
-        secret=__client_secret
-    )
-
-    with Trakt.configuration.http(retry=True):
-        imdb_id = get_imdb_id(uniqueids)
-        movie_info = Trakt['movies'].get(imdb_id, extended='full').to_dict()
-        result = {}
-        if(movie_info):
-            if 'votes' in movie_info and 'rating' in movie_info:
-                result['ratings'] = {'trakt': {'votes': int(movie_info['votes']), 'rating': float(movie_info['rating'])}}
-            elif 'rating' in movie_info:
-                result['ratings'] = {'trakt': {'rating': float(movie_info['rating'])}}
-
-        return result
+    imdb_id = get_imdb_id(uniqueids)
+    result = {}
+    url = MOVIE_URL.format(imdb_id)
+    params = {'extended': 'full'}
+    movie_info = api_utils.load_info(url, params=params, default={})
+    if(movie_info):
+        if 'votes' in movie_info and 'rating' in movie_info:
+            result['ratings'] = {'trakt': {'votes': int(movie_info['votes']), 'rating': float(movie_info['rating'])}}
+        elif 'rating' in movie_info:
+            result['ratings'] = {'trakt': {'rating': float(movie_info['rating'])}}
+    return result

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,7 +5,7 @@
 		<setting label="30000" type="bool" id="fanart" default="true"/>
 		<setting label="30012" type="bool" id="landscape" default="true"/>
 		<setting label="30004" type="bool" id="trailer" default="true"/>
-		<setting label="30002" type="select" values="ar-AE|ar-SA|be-BY|bg|bn-BD|ca-ES|ch-GU|cs|da|de|el|en|eo-EO|es|es-MX|et-EE|eu-ES|fa|fa-IR|fi|fr|fr-CA|gl|he|hi-IN|hr|hu|id-ID|it|ja|ka-GE|ko|lt-LT|lv-LV|ml-IN|nb|nl|no|pl|pt|pt-BR|ro|ru|sk|sl|sr|sv|ta-IN|th|tr|uk|vi-VN|zh|zh-TW|zh-HK" id="language" default="en"/>
+		<setting label="30002" type="select" values="ar-AE|ar-SA|be-BY|bg-BG|bn-BD|ca-ES|ch-GU|cs-CZ|da-DK|de-DE|el-GR|en-US|eo-EO|es-ES|es-MX|et-EE|eu-ES|fa-IR|fi-FI|fr-CA|fr-FR|gl-ES|he-IL|hi-IN|hr-HR|hu-HU|id-ID|it-IT|ja-JP|ka-GE|ko-KR|lt-LT|lv-LV|ml-IN|nb-NO|nl-NL|no-NO|pl-PL|pt-BR|pt-PT|ro-RO|ru-RU|sk-SK|sl-SI|sr-RS|sv-SE|ta-IN|th-TH|tr-TR|uk-UA|vi-VN|zh-CN|zh-HK|zh-TW" id="language" default="en-US"/>
 		<setting label="30006" type="select" values="au|bg|br|by|ca|cz|ge|de|dk|ee|es|fi|fr|gb|gr|hr|hu|id|il|in|it|ir|jp|kr|lt|lv|mx|nl|no|pl|pt|ru|si|sv|th|tr|ua|us|vn|zh" id="tmdbcertcountry" default="us"/>
 		<setting label="30008" type="text" id="certprefix" default="Rated " />
 		<setting label="30003" type="labelenum" values="TMDb|IMDb|Trakt" id="RatingS" default="TMDb"/>


### PR DESCRIPTION
This is the bundle of code changes to remove the dependencies on tmdbsimple, trakt, and requests modules. All the external calls are now handled by urllib2 (Python 2) or urllib (Python 3). I tried to minimize the changes to the core of the code, so tmdbapi.py mostly mimics the previous API calls and the changes to traktratings.py, imdbratings.py, and fanarttv.py are all internal.  There are two sets of changes to tmdb.py.

1. all the error handling for URL requests is now handled in api_utils or tmdbapi, so the logic to check for raised errors was updated.
1. With direct API calls images can now be returned with the primary query with different language requirements (images that match the language in the settings, English, or NULL are returned). That means the images are now loaded with the primary movie dict instead of the fallback one.