### PR TITLE
Handle case where is_best function has multiple hits

### DIFF
--- a/python/lib/tmdbscraper/tmdb.py
+++ b/python/lib/tmdbscraper/tmdb.py
@@ -40,10 +40,10 @@ class TMDBMovieScraper(object):
         def is_best(item):
             return item['title'].lower() == title and (
                 not year or item.get('release_date', '').startswith(year))
-        if result and not is_best(result[0]):
-            best_first = next((item for item in result if is_best(item)), None)
-            if best_first:
-                result = [best_first] + [item for item in result if item is not best_first]
+        if result:
+            # move all `is_best` results at the beginning of the list:
+            bests_first = [item for item in result if is_best(item)]
+            result = bests_first + [item for item in result if item not in bests_first]
 
         for item in result:
             if item.get('poster_path'):


### PR DESCRIPTION
Previous code [best_first] would only move one of the them at the
beginning.

For example:

https://api.themoviedb.org/3/search/movie?api_key=xyz&language=fr-FR&query=dragons&year=2010