### PR TITLE
Sort best matching movie results by popularity

### DIFF
--- a/python/lib/tmdbscraper/tmdb.py
+++ b/python/lib/tmdbscraper/tmdb.py
@@ -41,8 +41,8 @@ class TMDBMovieScraper(object):
             return item['title'].lower() == title and (
                 not year or item.get('release_date', '').startswith(year))
         if result:
-            # move all `is_best` results at the beginning of the list:
-            bests_first = [item for item in result if is_best(item)]
+            # move all `is_best` results at the beginning of the list, sort them by popularity (if found):
+            bests_first = sorted([item for item in result if is_best(item)], key=lambda k: k.get('popularity',0), reverse=True)
             result = bests_first + [item for item in result if item not in bests_first]
 
         for item in result:


### PR DESCRIPTION
When searching movies based solely on title and year, there may be
multiple hits as seen in commit: 80c27ac

This commit make sure to order those multiple best matching results by
popularity. This should make sure user gets the most likely result
first.

Results for 'Dragons' + '2010' + fr-FR will be in that order:

1. https://www.themoviedb.org/movie/10191-how-to-train-your-dragon?language=fr-FR
2. https://www.themoviedb.org/movie/40911?language=fr-FR

Documentation at:

* https://developers.themoviedb.org/3/search/search-movies

indicates that 'popularity' (number) is an optional response key, the
code defaults to 0 when key is not present.