### PR TITLE
API change to return all posters so that scraper can sort them later

### DIFF
--- a/python/lib/tmdbscraper/tmdb.py
+++ b/python/lib/tmdbscraper/tmdb.py
@@ -68,6 +68,7 @@ class TMDBMovieScraper(object):
 
         # don't specify language to get English text for fallback
         movie_fallback = _get_movie(media_id)
+        movie['images'] = movie_fallback['images']
 
         collection = _get_moviecollection(movie['belongs_to_collection'].get('id'), self.language) if \
             movie['belongs_to_collection'] else None
@@ -140,7 +141,7 @@ def _parse_media_id(title):
 def _get_movie(mid, language=None, search=False):
     details = None if search else \
         'trailers,images,releases,casts,keywords' if language is not None else \
-        'trailers'
+        'trailers,images'
     response = tmdbapi.get_movie(mid, language=language, append_to_response=details)
     theerror = response.get('error')
     if theerror:

--- a/python/lib/tmdbscraper/tmdbapi.py
+++ b/python/lib/tmdbscraper/tmdbapi.py
@@ -121,12 +121,8 @@ def get_configuration():
 
 def _set_params(append_to_response, language):
     params = TMDB_PARAMS.copy()
-    img_lang = 'en,null'
     if language is not None:
         params['language'] = language
-        img_lang = '%s,en,null' % language[0:2]
     if append_to_response is not None:
         params['append_to_response'] = append_to_response
-        if 'images' in append_to_response:
-            params['include_image_language'] = img_lang
     return params


### PR DESCRIPTION
This fixes the API wrapper so that it returns all poster images regardless of language so that the scraper can sort them out later. This makes it consistent with the old wrapper.