### PR TITLE
Change default ID to imdb

### DIFF
--- a/python/scraper.py
+++ b/python/scraper.py
@@ -122,7 +122,7 @@ def get_details(input_uniqueids, handle, settings):
     listitem = xbmcgui.ListItem(details['info']['title'], offscreen=True)
     listitem.setInfo('video', details['info'])
     listitem.setCast(details['cast'])
-    listitem.setUniqueIDs(details['uniqueids'], 'tmdb')
+    listitem.setUniqueIDs(details['uniqueids'], 'imdb')
     add_artworks(listitem, details['available_art'])
 
     for rating_type, value in details['ratings'].items():


### PR DESCRIPTION
During my migration to Matrix, it came to my attention that this new default scraper sets the `ListItem.IMDBNumber` InfoLabel inconsistently with the "old" XML-based scraper.

For example, after scanning (a subset of) my library in using the old scraper, I ran the following JSON-RPC command:
`{"jsonrpc":"2.0","id":17,"method":"VideoLibrary.GetMovies","params":{"properties":["uniqueid","imdbnumber"]}}`
And got this response back:
```json
{
    "id": 17,
    "jsonrpc": "2.0",
    "result": {
        "limits": {
            "end": 3,
            "start": 0,
            "total": 3
        },
        "movies": [
           {
                "imdbnumber": "tt0088763",
                "label": "Back to the Future",
                "movieid": 1,
                "uniqueid": {
                    "imdb": "tt0088763",
                    "tmdb": "105"
                }
            },
           {
                "imdbnumber": "tt0101452",
                "label": "Bill & Ted's Bogus Journey",
                "movieid": 2,
                "uniqueid": {
                    "imdb": "tt0101452",
                    "tmdb": "1649"
                }
            },
           {
                "imdbnumber": "tt2584384",
                "label": "Jojo Rabbit",
                "movieid": 3,
                "uniqueid": {
                    "imdb": "tt2584384",
                    "tmdb": "515001"
                }
            }
        ]
    }
}
```
Which shows that the IMDb ID is correctly set, and matches the "uniqueid" key for IMDb as well. A log can be found here: https://pastebin.com/w8NvT4pN

Using the new scraper, I ran the same JSON-RPC command, and got this response instead:
```json
{
    "id": 5,
    "jsonrpc": "2.0",
    "result": {
        "limits": {
            "end": 3,
            "start": 0,
            "total": 3
        },
        "movies": [
           {
                "imdbnumber": "105",
                "label": "Back to the Future",
                "movieid": 1,
                "uniqueid": {
                    "imdb": "tt0088763",
                    "tmdb": "105"
                }
            },
           {
                "imdbnumber": "1649",
                "label": "Bill & Ted's Bogus Journey",
                "movieid": 2,
                "uniqueid": {
                    "imdb": "tt0101452",
                    "tmdb": "1649"
                }
            },
           {
                "imdbnumber": "515001",
                "label": "Jojo Rabbit",
                "movieid": 3,
                "uniqueid": {
                    "imdb": "tt2584384",
                    "tmdb": "515001"
                }
            }
        ]
    }
}
```
So in the case of the new scraper, the **TMDb** ID is getting set as the IMDb ID, which isn't correct, and is inconsistent with the old scraper. A log of this can be found here: https://pastebin.com/dhwrbC8j

In this PR, I have fixed this issue by simply changing the "default" ID (as described [in the docs](https://codedocs.xyz/AlwinEsch/kodi/group__python__xbmcgui__listitem.html#ga7fc2ecd77b8d0032cc68eee6b4c9d6a2) to `'imdb'` instead of `'tmdb'`.

This results in consistent behavior with the old scraper, when making that same JSON-RPC call:
```json
{
    "id": 7,
    "jsonrpc": "2.0",
    "result": {
        "limits": {
            "end": 3,
            "start": 0,
            "total": 3
        },
        "movies": [
           {
                "imdbnumber": "tt0088763",
                "label": "Back to the Future",
                "movieid": 1,
                "uniqueid": {
                    "imdb": "tt0088763",
                    "tmdb": "105"
                }
            },
           {
                "imdbnumber": "tt0101452",
                "label": "Bill & Ted's Bogus Journey",
                "movieid": 2,
                "uniqueid": {
                    "imdb": "tt0101452",
                    "tmdb": "1649"
                }
            },
           {
                "imdbnumber": "tt2584384",
                "label": "Jojo Rabbit",
                "movieid": 3,
                "uniqueid": {
                    "imdb": "tt2584384",
                    "tmdb": "515001"
                }
            }
        ]
    }
}
```
Finally, a log of that can be found here: https://pastebin.com/TDNy722f

Unless there is a particular reason that this change was made, it seems odd for this inconsistency to be maintained, so I hope that this PR will be considered valid.