### PR TITLE
add option to enable / disable poster

### DIFF
--- a/python/scraper_config.py
+++ b/python/scraper_config.py
@@ -12,6 +12,11 @@ def configure_tmdb_artwork(details, settings):
         return details
 
     art = details['available_art']
+    if not settings.getSettingBool('fetch_posters'):
+        if 'poster' in art:
+            del art['poster']
+        if 'set.poster' in art:
+            del art['set.poster']
     fanart_enabled = settings.getSettingBool('fanart')
     if not fanart_enabled:
         if 'fanart' in art:

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -80,6 +80,10 @@ msgctxt "#30013"
 msgid "Search language"
 msgstr ""
 
+msgctxt "#30014"
+msgid "Enable posters from TMDb"
+msgstr ""
+
 msgctxt "#30100"
 msgid "Language for Fanart.tv artwork"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -138,6 +138,11 @@
 						<heading>30013</heading>
 					</control>
 				</setting>
+				<setting id="fetch_posters" type="boolean" label="30014" help="">
+					<level>0</level>
+					<default>true</default>
+					<control type="toggle"/>
+				</setting>
 				<setting id="fanart" type="boolean" label="30000" help="">
 					<level>0</level>
 					<default>true</default>


### PR DESCRIPTION
Kodi Artwork level None should also disable posters, but I don't doubt it fails in some case or another.