### PR TITLE
Support looking up via uniqueIDs (filename identifiers)

### DIFF
--- a/python/scraper.py
+++ b/python/scraper.py
@@ -95,13 +95,15 @@ def add_artworks(listitem, artworks):
         for image in artworks.get('fanart', ())[:IMAGE_LIMIT]]
     listitem.setAvailableFanart(fanart_to_set)
 
-def get_details(input_uniqueids, handle, settings):
+def get_details(input_uniqueids, handle, settings, fail_silently=False):
     if not input_uniqueids:
         return False
     details = get_tmdb_scraper(settings).get_details(input_uniqueids)
     if not details:
         return False
     if 'error' in details:
+        if fail_silently:
+            return False
         header = "The Movie Database Python error with web service TMDB"
         xbmcgui.Dialog().notification(header, details['error'], xbmcgui.NOTIFICATION_WARNING)
         log(header + ': ' + details['error'], xbmc.LOGWARNING)
@@ -174,8 +176,9 @@ def run():
         action = params["action"]
         if action == 'find' and 'title' in params:
             search_for_movie(params["title"], params.get("year"), params['handle'], settings)
-        elif action == 'getdetails' and 'url' in params:
-            enddir = not get_details(parse_lookup_string(params["url"]), params['handle'], settings)
+        elif action == 'getdetails' and ('url' in params or 'uniqueIDs' in params):
+            unique_ids = parse_lookup_string(params.get('uniqueIDs') or params.get('url'))
+            enddir = not get_details(unique_ids, params['handle'], settings, fail_silently='uniqueIDs' in params)
         elif action == 'NfoUrl' and 'nfo' in params:
             find_uniqueids_in_nfo(params["nfo"], params['handle'])
         else:


### PR DESCRIPTION
Add the needed changes for looking up by unique identifiers required for supporting [filename identifiers](https://github.com/xbmc/xbmc/pull/23840). The current implementation allows only for `tmdb` and `imdb` identifiers because no additional call to [find by id](https://developer.themoviedb.org/reference/find-by-id) is done. tmdb does support looking up by Facebook, Instagram, TikTok, Twitter, Wikidata and YouTube but the benefit of those identifiers is questionable. The normal tmdb movie API accepts `imdb` identifiers which is probably the most common identifier besides native `tmdb` identifiers.

The implementation does not catch errors which means that if a wrong identifier is supplied in the filename an error message is shown in kodi. It is up to debate if it would be better to catch the exception in case of a unique identifier lookup and fail silently. If a movie could not be looked up, Kodi falls back to the traditional lookup by title and year.  