### PR TITLE
Tag version 2.2.0

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org.python"
        name="The Movie Database Python"
-       version="2.1.0"
+       version="2.2.0"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
@@ -11,7 +11,10 @@
              library="python/scraper.py"/>
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
-    <news>v2.1.0 (2023-03-18)
+    <news>v2.2.0 (2024-01-10)
+- Support IMDB/TMDB IDs in filename for Kodi 21 Omega (uniqueIDs directly from Kodi)
+
+v2.1.0 (2023-03-18)
 - Add option to disable posters
 - Fix fallback language for landscape images
 - Don't add SVG image artwork

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v2.2.0 (2024-01-10)
+- Support IMDB/TMDB IDs in filename for Kodi 21 Omega (uniqueIDs directly from Kodi)
+
 v2.1.0 (2023-03-18)
 - Add option to disable posters
 - Fix fallback language for landscape images


### PR DESCRIPTION
v2.2.0 (2024-01-10)
- Support IMDB/TMDB IDs in filename for Kodi 21 Omega (uniqueIDs directly from Kodi)