### PR TITLE
Update YouTube plugin url used for trailers

### DIFF
--- a/python/lib/tmdbscraper/tmdb.py
+++ b/python/lib/tmdbscraper/tmdb.py
@@ -236,9 +236,9 @@ def _load_base_urls(url_settings):
 
 def _parse_trailer(trailers, fallback):
     if trailers.get('youtube'):
-        return 'plugin://plugin.video.youtube/?action=play_video&videoid='+trailers['youtube'][0]['source']
+        return 'plugin://plugin.video.youtube/play/?video_id='+trailers['youtube'][0]['source']
     if fallback.get('youtube'):
-        return 'plugin://plugin.video.youtube/?action=play_video&videoid='+fallback['youtube'][0]['source']
+        return 'plugin://plugin.video.youtube/play/?video_id='+fallback['youtube'][0]['source']
     return None
 
 def _get_names(items):


### PR DESCRIPTION
The plugin.video.youtube addon has supported a newer url format for quite some time.

While the old format is meant to be deprecated, the fact that it is saved in the Kodi video database means that actually disabling support for the old query parameters may not actually be feasible.

Regardless, updating the format used by the Kodi scrapers would be the first step towards doing so.