### PR TITLE
tag version 3.1.0

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.themoviedb.org.python"
        name="The Movie Database Python"
-       version="3.0.1"
+       version="3.1.0"
        provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.metadata" version="2.1.0"/>
@@ -11,17 +11,15 @@
              library="python/scraper.py"/>
   <extension point="xbmc.addon.metadata">
     <reuselanguageinvoker>true</reuselanguageinvoker>
-    <news>v3.0.1 (2024-04-22)
+    <news>v3.1.0 (2024-12-28)
+- add option to increase available artwork per art type
+- fix for inability to scrape IMDB ratings
+
+v3.0.1 (2024-04-22)
 - fix scraper error when tags are disabled
 
 v3.0.0 (2024-04-17)
-- version 3 for Kodi 20 Nexus and above
-
-v2.2.1 (2024-04-12)
-- Update YouTube plugin URL for trailers
-
-v2.2.0 (2024-01-10)
-- Support IMDB/TMDB IDs in filename for Kodi 21 Omega (uniqueIDs directly from Kodi)</news>
+- version 3 for Kodi 20 Nexus and above</news>
     <platform>all</platform>
     <license>GPL-2.0-or-later</license>
     <forum>https://forum.kodi.tv/showthread.php?tid=344580</forum>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+v3.1.0 (2024-12-28)
+- add option to increase available artwork per art type
+- fix for inability to scrape IMDB ratings
+
 v3.0.1 (2024-04-22)
 - fix scraper error when tags are disabled
 


### PR DESCRIPTION
v3.1.0 (2024-12-28)
- add option to increase available artwork per art type
- fix for inability to scrape IMDB ratings