### PR TITLE
Use Python 3.12 for addon-check

### DIFF
--- a/.github/workflows/addon-check.yml
+++ b/.github/workflows/addon-check.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
so 2to3 checks still work