### PR TITLE
add a whitelist option for "keywords as tags"

### DIFF
--- a/python/scraper_config.py
+++ b/python/scraper_config.py
@@ -75,6 +75,9 @@ def _configure_default_rating(details, settings):
 def _configure_tags(details, settings):
     if not settings.getSettingBool('add_tags'):
         del details['info']['tag']
+    elif settings.getSettingBool('enable_tag_whitelist'):
+        whitelist = set(tag.strip().lower() for tag in settings.getStringList('tag_whitelist'))
+        details['info']['tag'] = [tag for tag in details['info']['tag'] if tag.lower() in whitelist]
     return details
 
 # pylint: disable=invalid-name
@@ -101,6 +104,9 @@ class PathSpecificSettings(object):
 
     def getSettingString(self, id):
         return self._inner_get_setting(id, basestring, '')
+
+    def getStringList(self, id):
+        return self._inner_get_setting(id, list, [])
 
     def _inner_get_setting(self, setting_id, setting_type, default):
         value = self.data.get(setting_id)

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -88,6 +88,14 @@ msgctxt "#30015"
 msgid "Maximum number of each artwork type - many artwork can cause an error scraping to MySQL database"
 msgstr ""
 
+msgctxt "#30016"
+msgid "Only add whitelisted keywords as tags"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Tag whitelist"
+msgstr ""
+
 msgctxt "#30100"
 msgid "Language for Fanart.tv artwork"
 msgstr ""

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -89,6 +89,14 @@ msgctxt "#30015"
 msgid "Maximum number of each artwork type - many artwork can cause an error scraping to MySQL database"
 msgstr ""
 
+msgctxt "#30016"
+msgid "Only add whitelisted keywords as tags"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Tag whitelist"
+msgstr ""
+
 msgctxt "#30100"
 msgid "Language for Fanart.tv artwork"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -261,6 +261,34 @@
 					<default>true</default>
 					<control type="toggle"/>
 				</setting>
+				<setting id="enable_tag_whitelist" parent="add_tags" type="boolean" label="30016" help="">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
+					<dependencies>
+						<dependency type="enable" setting="add_tags" operator="is">true</dependency>
+					</dependencies>
+				</setting>
+				<setting id="tag_whitelist" parent="add_tags" type="list[string]" label="30017" help="">
+					<level>0</level>
+					<default>aftercreditsstinger, duringcreditsstinger</default>
+					<constraints>
+						<options>
+							<option>aftercreditsstinger</option>
+							<option>duringcreditsstinger</option>
+						</options>
+						<delimiter>, </delimiter>
+						<allownewoption>true</allownewoption>
+					</constraints>
+					<dependencies>
+						<dependency type="enable" setting="add_tags" operator="is">true</dependency>
+						<dependency type="visible" setting="enable_tag_whitelist" operator="is">true</dependency>
+					</dependencies>
+					<control type="list" format="string">
+						<multiselect>true</multiselect>
+						<addbuttonlabel>15019</addbuttonlabel>
+					</control>
+				</setting>
 				<setting id="lastUpdated" type="string" help="">
 					<level>4</level>
 					<default>0</default>


### PR DESCRIPTION
Many tags can be undesirable, but specific tags can be useful.

For instance `aftercreditsstinger` and `duringcreditsstinger` are used by the [Stinger scene notification](https://forum.kodi.tv/showthread.php?tid=254004) add-on.